### PR TITLE
Add game repository with MongoDB

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@ using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using chessAPI;
 using chessAPI.business.interfaces;
+using chessAPI.models.game;
 using chessAPI.models.player;
 using Microsoft.AspNetCore.Authorization;
 using Serilog;
@@ -38,13 +39,37 @@ try
     var app = builder.Build();
     app.UseSerilogRequestLogging();
     app.UseMiddleware(typeof(chessAPI.customMiddleware<int>));
-    app.MapGet("/", () =>
+
+    #region "REST routes"
+    app.MapGet("/", () => Results.BadRequest());
+
+    #region "Player REST Commands"
+    app.MapGet("game/{id}", async (IGameBusiness bs, long id) =>
     {
-        return "hola mundo";
+        var x = await bs.getGame(id).ConfigureAwait(false);
+        return x != null ? Results.Ok(x) : Results.NotFound();
     });
 
-    app.MapPost("player", 
-    [AllowAnonymous] async(IPlayerBusiness<int> bs, clsNewPlayer newPlayer) => Results.Ok(await bs.addPlayer(newPlayer)));
+    app.MapPost("player",
+    [AllowAnonymous] async (IPlayerBusiness<int> bs, clsNewPlayer newPlayer)
+        => Results.Ok(await bs.addPlayer(newPlayer).ConfigureAwait(false)));
+    #endregion
+
+    #region "Game REST Commands"
+    app.MapPost("game",
+    [AllowAnonymous] async (IGameBusiness bs, clsNewGame newGame) =>
+    {
+        await bs.startGame(newGame).ConfigureAwait(false);
+        return Results.Ok();
+    });
+    app.MapPut("/game/{id}/swapturn",
+    [AllowAnonymous] async (IGameBusiness bs, long id) =>
+    {
+        var didSwap = await bs.swapTurn(id).ConfigureAwait(false);
+        return didSwap ? Results.Ok() : Results.BadRequest();
+    });
+    #endregion
+    #endregion
 
     app.Run();
 }

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ dotnet dev-certs https --trust
 ```
 docker volume create pg_main_data
 docker volume create pga4data
+docker volume create mongoData
 ```
 This will install the needed dependencies to store our API, the default database is PostgreSQL but feel free to adjust the app to whatever best suits you for a development database.
 
@@ -86,7 +87,8 @@ Add additional notes about how to deploy this on a live system.
 - [Autofac](https://autofac.org/)
 - [Dapper](https://github.com/DapperLib/Dapper)
 - [Serilog](https://serilog.net/)
-- [PostgreSQL](https://www.postgresql.org/) - Database
+- [PostgreSQL](https://www.postgresql.org/) - Relational Database
+- [MongoDB](https://www.mongodb.com/) - Non Relational Database
 - [ASP.Net](https://dotnet.microsoft.com/en-US/apps/aspnet) - Server Framework
 - [.Net 7](https://dotnet.microsoft.com/en-US/) - Server Environment
 

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -6,6 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "relationalDBConn": "Server=localhost;Port=5432;Database=chessDB;User Id=postgres;Password=misDatos2023!;Pooling=true;MinPoolSize=3;MaxPoolSize=20;Max Auto Prepare=15;Enlist=false;Auto Prepare Min Usages=3"
+    "relationalDBConn": "Server=localhost;Port=5432;Database=chessDB;User Id=postgres;Password=misDatos2023!;Pooling=true;MinPoolSize=3;MaxPoolSize=20;Max Auto Prepare=15;Enlist=false;Auto Prepare Min Usages=3",
+    "mongoDbConn": "mongodb://root:example@localhost:27017/"
   }
 }

--- a/business/impl/clsGameBusiness.cs
+++ b/business/impl/clsGameBusiness.cs
@@ -1,0 +1,31 @@
+using chessAPI.dataAccess.repositores;
+using chessAPI.models.game;
+using chessAPI.business.interfaces;
+
+namespace chessAPI.business.impl;
+
+public sealed class clsGameBusiness : IGameBusiness
+{
+    internal readonly IGameRepository gameRepository;
+
+    public clsGameBusiness(IGameRepository gameRepository) => this.gameRepository = gameRepository;
+
+    public async Task startGame(clsNewGame newGame) => await gameRepository.addGame(newGame).ConfigureAwait(false);
+
+    public async Task<clsGame?> getGame(long id)
+    {
+        var x = await gameRepository.getGame(id).ConfigureAwait(false);
+        return x != null ? (clsGame)x : null;
+    }
+
+    public async Task<bool> swapTurn(long id)
+    {
+        var x = await gameRepository.getGame(id).ConfigureAwait(false);
+        if (x != null)
+        {
+            await gameRepository.swapTurn(id).ConfigureAwait(false);
+            return true;
+        }
+        return false;
+    }
+}

--- a/business/interfaces/IGameBusiness.cs
+++ b/business/interfaces/IGameBusiness.cs
@@ -1,0 +1,10 @@
+using chessAPI.models.game;
+
+namespace chessAPI.business.interfaces;
+
+public interface IGameBusiness
+{
+    Task<clsGame?> getGame(long id);
+    Task startGame(clsNewGame newGame);
+    Task<bool> swapTurn(long id);
+}

--- a/chessAPI.csproj
+++ b/chessAPI.csproj
@@ -7,10 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.5.0" />
+    <PackageReference Include="Autofac" Version="7.0.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Npgsql" Version="7.0.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+    <PackageReference Include="Npgsql" Version="7.0.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>

--- a/connectionStrings.cs
+++ b/connectionStrings.cs
@@ -1,8 +1,16 @@
 namespace chessAPI;
+
 public sealed class connectionStrings
+{
+    public connectionStrings()
     {
-        /// <summary>
-        /// Cadena de conexión a base de datos relacional
-        /// </summary>
-        public string relationalDBConn { get; set; }
+        relationalDBConn = "";
+        mongoDbConn = "";
     }
+
+    /// <summary>
+    /// Cadena de conexión a base de datos relacional
+    /// </summary>
+    public string relationalDBConn { get; set; }
+    public string mongoDbConn { get; set; }
+}

--- a/dataAccess/common/clsDataAccess.cs
+++ b/dataAccess/common/clsDataAccess.cs
@@ -37,7 +37,7 @@ public abstract class clsDataAccess<TEntity, TKey, TC>
         protected abstract DynamicParameters keyAsParams(TKey key);
         protected abstract DynamicParameters fieldsAsParams(TEntity entity); //Populate DBParams with all fields in the table
 
-        protected async Task<IEnumerable<T>> get<T>(DynamicParameters param, string query, CommandType commandType = CommandType.Text)
+        protected async Task<IEnumerable<T>?> get<T>(DynamicParameters param, string query, CommandType commandType = CommandType.Text)
         {
             try
             {
@@ -55,17 +55,17 @@ public abstract class clsDataAccess<TEntity, TKey, TC>
             }
         }
 
-        protected async Task<IEnumerable<TEntity>> get(DynamicParameters param, string query)
+        protected async Task<IEnumerable<TEntity>?> get(DynamicParameters param, string query)
         {
             return await get<TEntity>(param, query).ConfigureAwait(false);
         }
 
-        protected async Task<IEnumerable<TEntity>> getALL(DynamicParameters param)
+        protected async Task<IEnumerable<TEntity>?> getALL(DynamicParameters param)
         {
             return await get<TEntity>(param, queries.SQLGetAll).ConfigureAwait(false);
         }
 
-        protected async Task<TEntity>? getEntity(TKey key, bool UseCache = true)
+        protected async Task<TEntity?> getEntity(TKey key, bool UseCache = true)
         {
             TEntity? result;
             if (UseCache == true && cache != null)
@@ -76,6 +76,7 @@ public abstract class clsDataAccess<TEntity, TKey, TC>
             var p = keyAsParams(key);
             var data = await get(p, queries.SQLDataEntity).ConfigureAwait(false);
             cache = data;
+
             return data?.FirstOrDefault();
         }
 
@@ -87,7 +88,7 @@ public abstract class clsDataAccess<TEntity, TKey, TC>
                     param: param,
                     transaction: rkm.trn,
                     commandType: CommandType.Text).ConfigureAwait(false);
-                return result.FirstOrDefault();
+                return result.First();
             }
             catch (SqlException ex)
             {
@@ -207,7 +208,7 @@ public abstract class clsDataAccess<TEntity, TKey, TC>
             await set(p, RowVersion, queries.UpdateWholeEntity).ConfigureAwait(false);
         }
 
-        protected async Task<TResult> set<TResult>(DynamicParameters param, TC? rowVersion, string query, Action<TResult> setFields)
+        protected async Task<TResult?> set<TResult>(DynamicParameters param, TC? rowVersion, string query, Action<TResult> setFields)
         {
             try
             {
@@ -218,13 +219,13 @@ public abstract class clsDataAccess<TEntity, TKey, TC>
                 var x = await rkm.trn.Connection.QueryAsync<TResult>(sql: query, param: param,
                                                                      transaction: rkm.trn,
                                                                      commandType: CommandType.Text).ConfigureAwait(false);
-                if (x != null)
+                if (x != null && x.Any())
                 {
                     if (cacheddata == true)
                     {
-                        setFields?.Invoke(x.FirstOrDefault());
+                        setFields?.Invoke(x!.First());
                     }
-                    return x.FirstOrDefault();
+                    return x!.First();
                 }
                 throw new DBConcurrencyException("Error de concurrencia en la base de datos");
             }

--- a/dataAccess/common/clsRelationalContext.cs
+++ b/dataAccess/common/clsRelationalContext.cs
@@ -10,7 +10,8 @@ public sealed class clsRelationalContext<TC> : IRelationalContext<TC>
     private readonly IDbConnection dbConn;
     private bool connActive;
 
-    public IDbTransaction trn { get; private set; } = null;
+    public IDbTransaction trn { get; private set; } = null!;
+
     public ILogger<clsRelationalContext<TC>> logger { get; private set; }
     public IDBConcurrencyHandler<TC> concurrencyHandler { get; private set; }
 

--- a/dataAccess/models/clsGameEntityModel.cs
+++ b/dataAccess/models/clsGameEntityModel.cs
@@ -1,0 +1,44 @@
+namespace chessAPI.dataAccess.models;
+
+using chessAPI.models.game;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+public sealed class clsGameEntityModel
+{
+    public clsGameEntityModel()
+    {
+    }
+
+    public clsGameEntityModel(clsNewGame newGame, long id)
+    {
+        this.whites = newGame.whites;
+        this.blacks = newGame.blacks;
+        this.turn = newGame.turn;
+        this.id = id;
+        this.started = DateTimeOffset.Now;
+    }
+
+    public ObjectId Id { get; set; }
+
+    [BsonElement("id_game")]
+    public long id { get; set; }
+    public DateTimeOffset started { get; set; }
+    public int whites { get; set; }
+    public int blacks { get; set; }
+    public bool turn { get; set; }
+    public int winner { get; set; }
+
+    public static explicit operator clsGame(clsGameEntityModel x)
+    {
+        return new clsGame()
+        {
+            id = x.id,
+            started = x.started,
+            whites = x.whites,
+            blacks = x.blacks,
+            turn = x.turn,
+            winner = x.winner
+        };
+    }
+}

--- a/dataAccess/repositories/IGameRepository.cs
+++ b/dataAccess/repositories/IGameRepository.cs
@@ -1,0 +1,11 @@
+using chessAPI.dataAccess.models;
+using chessAPI.models.game;
+
+namespace chessAPI.dataAccess.repositores;
+
+public interface IGameRepository
+{
+    Task addGame(clsNewGame newGame);
+    Task<clsGameEntityModel?> getGame(long id);
+    Task swapTurn(long id);
+}

--- a/dataAccess/repositories/clsGameRepository.cs
+++ b/dataAccess/repositories/clsGameRepository.cs
@@ -1,0 +1,45 @@
+using chessAPI.dataAccess.models;
+using chessAPI.models.game;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace chessAPI.dataAccess.repositores;
+
+public sealed class clsGameRepository : IGameRepository
+{
+    private readonly IMongoCollection<clsGameEntityModel> gameCollection;
+
+    public clsGameRepository(IMongoCollection<clsGameEntityModel> gameCollection)
+    {
+        this.gameCollection = gameCollection;
+    }
+
+    private async Task<long> getLastGame()
+    {
+        //Empty document tells the driver to count all the documents in the collection
+        return await gameCollection.CountDocumentsAsync(new BsonDocument());
+    }
+
+    public async Task addGame(clsNewGame newGame)
+    {
+        var newId = await getLastGame().ConfigureAwait(false) + 1;
+        await gameCollection.InsertOneAsync(new clsGameEntityModel(newGame, newId)).ConfigureAwait(false);
+    }
+
+    public async Task<clsGameEntityModel?> getGame(long id)
+    {
+        var filter = Builders<clsGameEntityModel>.Filter.Eq(r => r.id, id);
+        return await gameCollection.Find(filter).FirstOrDefaultAsync().ConfigureAwait(false);
+    }
+
+    public async Task swapTurn(long id)
+    {
+        var gameToSwap = await getGame(id).ConfigureAwait(false);
+        if (gameToSwap != null)
+        {
+            var update = Builders<clsGameEntityModel>.Update.Set(g => g.turn, !gameToSwap.turn);
+            var filter = Builders<clsGameEntityModel>.Filter.Eq(r => r.id, id);
+            await gameCollection.UpdateOneAsync(filter, update);
+        }
+    }
+}

--- a/dependencyInjection.cs
+++ b/dependencyInjection.cs
@@ -1,6 +1,7 @@
 using Autofac;
 using Npgsql;
 using Microsoft.Extensions.Options;
+using MongoDB.Driver;
 using System.Data;
 using chessAPI.dataAccess.providers.postgreSQL;
 using chessAPI.dataAccess.interfaces;
@@ -10,6 +11,8 @@ using chessAPI.dataAccess.queries;
 using chessAPI.dataAccess.repositores;
 using chessAPI.business.interfaces;
 using chessAPI.business.impl;
+using MongoDB.Bson;
+using chessAPI.dataAccess.models;
 
 namespace chessAPI;
 
@@ -20,11 +23,22 @@ where TI : struct, IEquatable<TI>
     protected override void Load(ContainerBuilder builder)
     {
         base.Load(builder);
+
+        //Relational datastore
         builder.Register(c => new NpgsqlConnection(c.Resolve<IOptions<connectionStrings>>().Value.relationalDBConn))
             .InstancePerLifetimeScope()
             .As<IDbConnection>();
 
-        #region "Low level DAL Infrastructure"
+        //Non-relational datastore
+        builder.Register(c=> new MongoClient(c.Resolve<IOptions<connectionStrings>>().Value.mongoDbConn))
+            .SingleInstance()
+            .As<IMongoClient>();
+        
+        builder.Register(c=> c.Resolve<IMongoClient>().GetDatabase("chess"))
+            .SingleInstance()
+            .As<IMongoDatabase>();
+
+        #region "Low level relational DAL Infrastructure"
         builder.Register(c => new clsConcurrency<TC>())
             .SingleInstance()
             .As<IDBConcurrencyHandler<TC>>();
@@ -35,18 +49,30 @@ where TI : struct, IEquatable<TI>
                 .As<IRelationalContext<TC>>();
         #endregion
 
+        #region "MongoDb Collections"
+        builder.Register(c=> c.Resolve<IMongoClient>().GetDatabase("chess").GetCollection<clsGameEntityModel>("games"))
+            .InstancePerDependency()
+            .As<IMongoCollection<clsGameEntityModel>>();
+        #endregion
+
         #region "Queries"
         builder.Register(c => new qPlayer())
           .SingleInstance()
           .As<IQPlayer>();
         #endregion
 
-        #region "Repositories"
+        #region "Relational Repositories"
         builder.Register(c => new clsPlayerRepository<TI, TC>(c.Resolve<IRelationalContext<TC>>(),
                                                               c.Resolve<IQPlayer>(),
                                                               c.Resolve<ILogger<clsPlayerRepository<TI, TC>>>()))
                .InstancePerDependency()
                .As<IPlayerRepository<TI, TC>>();
+        #endregion
+
+        #region "Non-Relational Repositories"
+        builder.Register(c=> new clsGameRepository(c.Resolve<IMongoCollection<clsGameEntityModel>>()))
+            .InstancePerDependency()
+            .As<IGameRepository>();
         #endregion
 
         #region "Kaizen Entity Factories"
@@ -61,6 +87,9 @@ where TI : struct, IEquatable<TI>
         builder.Register(c => new clsPlayerBusiness<TI, TC>(c.Resolve<IPlayerRepository<TI, TC>>()))
                .InstancePerDependency()
                .As<IPlayerBusiness<TI>>();
+        builder.Register(c => new clsGameBusiness(c.Resolve<IGameRepository>()))
+               .InstancePerDependency()
+               .As<IGameBusiness>();
         #endregion
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,29 @@ services:
       - pgdata
     networks:
       - backend
+  mongo:
+    image: mongo
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+    volumes:
+      - mongoData:/data/db
+    ports:
+      - 27017:27017
+    networks:
+      - backend
+  mongo-express:
+    image: mongo-express
+    restart: always
+    ports:
+      - 8081:8081
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: root
+      ME_CONFIG_MONGODB_ADMINPASSWORD: example
+      ME_CONFIG_MONGODB_URL: mongodb://root:example@mongo:27017/
+    networks:
+      - backend
 networks:
   backend:
     driver: bridge
@@ -45,4 +68,6 @@ volumes:
   pg_main_data:
     external: true
   pga4data:
+    external: true
+  mongoData:
     external: true

--- a/liquibase/changelog-root.xml
+++ b/liquibase/changelog-root.xml
@@ -1,6 +1,6 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
-    <changeSet author="liquibase (generated)" id="1675207050898-1">
+    <changeSet author="liquibase (generated)" id="1675297724576-1">
         <createTable tableName="game">
             <column autoIncrement="true" name="id" type="INTEGER">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="game_pkey"/>
@@ -20,7 +20,7 @@
             <column name="winner" type="INTEGER"/>
         </createTable>
     </changeSet>
-    <changeSet author="liquibase (generated)" id="1675207050898-2">
+    <changeSet author="liquibase (generated)" id="1675297724576-2">
         <createTable remarks="Represent the relationship between a player and it's pieces, one player can have many pieces and any particular piece type can be owned by many players" tableName="player_piece">
             <column autoIncrement="true" name="id" type="BIGINT">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="player_piece_pkey"/>
@@ -31,7 +31,7 @@
             <column name="removed_on" type="TIMESTAMP WITHOUT TIME ZONE"/>
         </createTable>
     </changeSet>
-    <changeSet author="liquibase (generated)" id="1675207050898-3">
+    <changeSet author="liquibase (generated)" id="1675297724576-3">
         <createTable tableName="team">
             <column autoIncrement="true" name="id" type="INTEGER">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="team_pkey"/>
@@ -44,7 +44,7 @@
             </column>
         </createTable>
     </changeSet>
-    <changeSet author="liquibase (generated)" id="1675207050898-4">
+    <changeSet author="liquibase (generated)" id="1675297724576-4">
         <createTable remarks="Stores a game secuence" tableName="secuence">
             <column autoIncrement="true" name="id" type="BIGINT">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="secuence_pkey"/>
@@ -77,7 +77,7 @@
             <column defaultValueNumeric="0" name="score" type="INTEGER"/>
         </createTable>
     </changeSet>
-    <changeSet author="liquibase (generated)" id="1675207050898-5">
+    <changeSet author="liquibase (generated)" id="1675297724576-5">
         <createTable tableName="board">
             <column autoIncrement="true" name="id" type="BIGINT">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="board_pkey"/>
@@ -94,7 +94,7 @@
             <column name="player_piece_id" type="BIGINT"/>
         </createTable>
     </changeSet>
-    <changeSet author="liquibase (generated)" id="1675207050898-6">
+    <changeSet author="liquibase (generated)" id="1675297724576-6">
         <createTable tableName="piece">
             <column autoIncrement="true" name="id" type="SMALLINT">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="piece_pkey"/>
@@ -104,7 +104,7 @@
             </column>
         </createTable>
     </changeSet>
-    <changeSet author="liquibase (generated)" id="1675207050898-7">
+    <changeSet author="liquibase (generated)" id="1675297724576-7">
         <createTable tableName="player">
             <column autoIncrement="true" name="id" type="INTEGER">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="player_pkey"/>
@@ -114,7 +114,7 @@
             </column>
         </createTable>
     </changeSet>
-    <changeSet author="liquibase (generated)" id="1675207050898-8">
+    <changeSet author="liquibase (generated)" id="1675297724576-8">
         <createTable remarks="Relationship between teams and players, one team is conformed by many players, and one player can belong to many chess teams" tableName="team_player">
             <column autoIncrement="true" name="id" type="INTEGER">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="team_player_pkey"/>
@@ -127,25 +127,25 @@
             </column>
         </createTable>
     </changeSet>
-    <changeSet author="liquibase (generated)" id="1675207050898-9">
+    <changeSet author="liquibase (generated)" id="1675297724576-9">
         <addForeignKeyConstraint baseColumnNames="game_id" baseTableName="board" constraintName="fk_board_game" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="game" validate="true"/>
     </changeSet>
-    <changeSet author="liquibase (generated)" id="1675207050898-10">
+    <changeSet author="liquibase (generated)" id="1675297724576-10">
         <addForeignKeyConstraint baseColumnNames="player_piece_id" baseTableName="board" constraintName="fk_board_piece" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="player_piece" validate="true"/>
     </changeSet>
-    <changeSet author="liquibase (generated)" id="1675207050898-11">
+    <changeSet author="liquibase (generated)" id="1675297724576-11">
         <addForeignKeyConstraint baseColumnNames="whites" baseTableName="game" constraintName="fk_game_team1" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="team" validate="true"/>
     </changeSet>
-    <changeSet author="liquibase (generated)" id="1675207050898-12">
+    <changeSet author="liquibase (generated)" id="1675297724576-12">
         <addForeignKeyConstraint baseColumnNames="blacks" baseTableName="game" constraintName="fk_game_team2" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="team" validate="true"/>
     </changeSet>
-    <changeSet author="liquibase (generated)" id="1675207050898-13">
+    <changeSet author="liquibase (generated)" id="1675297724576-13">
         <addForeignKeyConstraint baseColumnNames="winner" baseTableName="game" constraintName="fk_game_winner" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="team" validate="true"/>
     </changeSet>
-    <changeSet author="liquibase (generated)" id="1675207050898-14">
+    <changeSet author="liquibase (generated)" id="1675297724576-14">
         <addForeignKeyConstraint baseColumnNames="player_id" baseTableName="team_player" constraintName="fk_tp_player" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="player" validate="true"/>
     </changeSet>
-    <changeSet author="liquibase (generated)" id="1675207050898-15">
+    <changeSet author="liquibase (generated)" id="1675297724576-15">
         <addForeignKeyConstraint baseColumnNames="team_id" baseTableName="team_player" constraintName="fk_tp_team" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="team" validate="true"/>
     </changeSet>
 </databaseChangeLog>

--- a/models/game/clsGame.cs
+++ b/models/game/clsGame.cs
@@ -1,0 +1,11 @@
+namespace chessAPI.models.game;
+
+public sealed class clsGame
+{
+    public long id { get; set; }
+    public DateTimeOffset started { get; set; }
+    public int whites { get; set; }
+    public int blacks { get; set; }
+    public bool turn { get; set; }
+    public int winner { get; set; }
+}

--- a/models/game/clsNewGame.cs
+++ b/models/game/clsNewGame.cs
@@ -1,0 +1,8 @@
+namespace chessAPI.models.game;
+
+public sealed class clsNewGame
+{
+    public int whites {get;set;}
+    public int blacks {get;set;}
+    public bool turn {get;set;}
+}


### PR DESCRIPTION
Description of the change:
- Added a new repository for games, using MongoDb as it's data-store
- Added all the pipelining for MongoDb connection and services-injection
- Added MongoDb as a service in the docker-compose file
- Added Mongo-Express as a admin-UI for mongoDb
- The new business layer for games has the following three operations:

1. Add Game (create a new document in Mongo)
2. Get Game (get the game based on the Id)
3. Swap turns (swapping turn between whites team and black teams)

Beware of the new docker volume needed to run this (see Readme.md)